### PR TITLE
Sym path compat and errors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -465,7 +465,7 @@ async fn run() -> anyhow::Result<()> {
 
         match download_manifest(args[2].clone(), lines).await {
             Ok(_) => println!("Success!"),
-            Err(e) => println!("Failed: {}", e),
+            Err(e) => println!("Failed: {:#}", e),
         }
     } else if args.len() == 4 && args[1] == "download_single" {
         let ctx = SymContext::new(args[2].clone()).context("failed to create symbol context")?;

--- a/src/symsrv.rs
+++ b/src/symsrv.rs
@@ -124,7 +124,7 @@ impl FromStr for SymSrv {
         match directives.first() {
             // Simply exit the match statement if the directive is "SRV"
             Some(x) => {
-                if "SRV" == *x {
+                if "SRV" == x.to_ascii_uppercase() {
                     if directives.len() != 3 {
                         anyhow::bail!("");
                     }

--- a/src/symsrv.rs
+++ b/src/symsrv.rs
@@ -124,7 +124,7 @@ impl FromStr for SymSrv {
         match directives.first() {
             // Simply exit the match statement if the directive is "SRV"
             Some(x) => {
-                if "SRV" == x.to_ascii_uppercase() {
+                if x.eq_ignore_ascii_case("SRV") {
                     if directives.len() != 3 {
                         anyhow::bail!("Unsupported server string form; only 'SRV*<CACHE_PATH>*<SYMBOL_SERVER>' supported");
                     }

--- a/src/symsrv.rs
+++ b/src/symsrv.rs
@@ -126,7 +126,7 @@ impl FromStr for SymSrv {
             Some(x) => {
                 if "SRV" == x.to_ascii_uppercase() {
                     if directives.len() != 3 {
-                        anyhow::bail!("");
+                        anyhow::bail!("Unsupported server string form; only 'SRV*<CACHE_PATH>*<SYMBOL_SERVER>' supported");
                     }
 
                     // Alright, the directive is of the proper form. Return the server and filepath.
@@ -138,11 +138,13 @@ impl FromStr for SymSrv {
             }
 
             None => {
-                anyhow::bail!("Unsupported server string form");
+                anyhow::bail!("Unsupported server string form; only 'SRV*<CACHE_PATH>*<SYMBOL_SERVER>' supported");
             }
         };
 
-        unreachable!();
+        anyhow::bail!(
+            "Unsupported server string form; only 'SRV*<CACHE_PATH>*<SYMBOL_SERVER>' supported"
+        );
     }
 }
 


### PR DESCRIPTION
Case mismatch in the symbol server path means `srv*` causes pdblister to fail to proceed. There's no reason to fail here, this PR normalizes the `srv` components case before checking.

This PR also adds clearer error messages around this, and makes anyhow show the cause of failures to download.