### PR TITLE
Convert over to clap for arg parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,6 +66,28 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "4.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91b9970d7505127a162fdaa9b96428d28a479ba78c9ec7550a63a5d9863db682"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_lex",
+ "strsim",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+dependencies = [
+ "os_str_bytes",
+]
 
 [[package]]
 name = "console"
@@ -557,6 +590,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,6 +624,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "base64",
+ "clap",
  "futures",
  "indicatif",
  "mime",
@@ -850,6 +890,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -884,6 +930,15 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1182,6 +1237,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ reqwest = "0.11"
 thiserror = "1.0"
 url = "2.2"
 zerocopy = "0.6"
+clap = "4.0.22"
 
 [dependencies.tokio]
 version = "1.14.0"

--- a/README.md
+++ b/README.md
@@ -10,62 +10,21 @@ infinite loops. Thus this is a stricter (and much faster) alternative.
 The output manifest is compatible with symchk. If you want to use symchk
 in lieu of this tool, use `symchk /im manifest /s <symbol path>`
 
+Note that we currently offer **no guarantee of stability** for the
+command-line options of this tool. If you need stability, please install a
+specific version.
+
 ![](docs/images/download.gif)
 
-# Usage
+# Quick Start
 
-Usage:
+```
+# On your target
+> cargo run --release -- manifest C:\Windows\System32
 
-    pdblister [manifest | download | download_single | filestore | clean] <filepath>
- 
-    === Create manifest === 
-    
-        pdblister manifest <filepath>
-
-        This command takes in a filepath to recursively search for files that
-        have a corresponding PDB. This creates a file called `manifest` which
-        is compatible with symchk.
-        
-        For example `pdblister manifest C:\\windows` will create `manifest`
-        containing all of the PDB signatures for all of the files in
-        C:\\windows.
-
-    === Download from manifest ===
-
-        pdblister download <sympath>
-
-        This command takes no parameters. It simply downloads all the PDBs
-        specified in the `manifest` file.
-
-    === Download single executable ===
-
-        pdblister download_single <sympath> <exepath>
-
-        This command will take a symbol server URL and executable path, and
-        use the symbol server to download the PDB file for the executable to
-        the cache directory.
-
-    === Create a file store ===
-
-        pdblister filestore <filepath>
-
-        This command recursively walks filepath to find all PEs. Any PE file
-        that is found is copied to the local directory 'filestore' using the
-        layout that symchk.exe uses to store normal files. This is used to
-        create a store of all PEs (such as .dlls), which can be used by a
-        kernel debugger to read otherwise paged out memory by downloading the
-        original PE source file from this filestore.
-
-        To use this filestore simply merge the contents in with a symbol
-        store/cache path. We keep it separate in this tool just to make it
-        easier to only get PDBs if that's all you really want.
-
-    === Clean ===
-
-        pdblister clean
-
-        This command removes the `manifest` file as well as the symbol folder
-        and the filestore folder
+# On an online machine
+> cargo run --release -- download SRV*C:\Symbols*https://msdl.microsoft.com/download/symbols
+```
 
 # Future
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -393,7 +393,7 @@ async fn run() -> anyhow::Result<()> {
                         .help("The root of the directory tree to search for PEs")
                         .required(true)
                 ]),
-        ]).get_matches();
+        ]).arg_required_else_help(true).get_matches();
 
     let it = Instant::now();
 

--- a/src/symsrv.rs
+++ b/src/symsrv.rs
@@ -421,10 +421,10 @@ pub struct SymContext {
 }
 
 impl SymContext {
-    pub fn new(srvstr: String) -> anyhow::Result<Self> {
+    pub fn new(srvstr: &str) -> anyhow::Result<Self> {
         // First, parse the server string to figure out where we're supposed to fetch symbols from,
         // and where to.
-        let servers = SymSrvList::from_str(&srvstr)?;
+        let servers = SymSrvList::from_str(srvstr)?;
 
         // Couple the servers with a reqwest client.
         let servers = servers


### PR DESCRIPTION
This changeset converts us over to use `clap` in anticipation of future changes to the arguments we will expose.

As for now, usage remains identical to how it was before and users should not notice any change apart from in the help text.