### PR TITLE
Remove `ADO_PAT` magic var ref, require auth for dev.azure.com

### DIFF
--- a/crates/symsrv/src/nonblocking.rs
+++ b/crates/symsrv/src/nonblocking.rs
@@ -261,14 +261,12 @@ fn connect_server(srv: &SymSrvSpec) -> anyhow::Result<reqwest::Client> {
         Some(Host::Domain(d)) => {
             match d {
                 // Azure DevOps
-                d if d.ends_with("artifacts.visualstudio.com") => {
-                    // Try and find the PAT for ADO, either from basic authentication or an ADO_PAT
-                    // environment variable.
+                d if d.ends_with("artifacts.visualstudio.com") || d.ends_with("dev.azure.com") => {
+                    // Try and find the PAT for ADO from URL basic authentication.
                     let pat = url
                         .password()
                         .map(|p| p.to_string())
-                        .or_else(|| std::env::var("ADO_PAT").ok())
-                        .context("PAT not specified for ADO")?;
+                        .context("ADO requires a PAT for authentication")?;
 
                     Ok(connect_pat(&pat)?)
                 }


### PR DESCRIPTION
The `ADO_PAT` magic env var reference was added before I figured out that we can pass the PAT in through the URL, and nothing actually uses `ADO_PAT` in practice.
In addition, this changeset adds auth for dev.azure.com.