### PR TITLE
Add the `tokio` feature for `indicatif` in the `symsrv` crate

### DIFF
--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 anyhow = "1.0"
 clap = "4.0.22"
 futures = "0.3"
-indicatif = { version = "0.17.1", features = ["tokio"] }
+indicatif = { version = "0.17.2", features = ["tokio"] }
 pdb = "0.8.0"
 rand = "0.8"
 serde_json = "1.0.87"

--- a/crates/symsrv/Cargo.toml
+++ b/crates/symsrv/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 anyhow = "1.0.66"
 base64 = "0.13"
 futures = "0.3.25"
-indicatif = "0.17.2"
+indicatif = { version = "0.17.2", features = ["tokio"] }
 mime = "0.3"
 reqwest = "0.11.13"
 thiserror = "1.0.37"


### PR DESCRIPTION
This feature was missing even though it's used inside `symsrv`, so external crates cannot depend on `symsrv` directly.