### PR TITLE
Fix download errors to be a bit more clear/verbose

### DIFF
--- a/crates/bin/src/main.rs
+++ b/crates/bin/src/main.rs
@@ -333,9 +333,7 @@ fn connect_servers(srvstr: &str) -> anyhow::Result<Box<[SymSrv]>> {
         .collect::<Result<Vec<_>, (SymSrvSpec, anyhow::Error)>>()
     {
         Ok(srv) => Ok(srv.into_boxed_slice()),
-        Err((s, e)) => {
-            anyhow::bail!("failed to connect to server {s}: {e:#}");
-        }
+        Err((s, e)) => Err(e.context(format!("failed to connect to server {s}"))),
     }
 }
 
@@ -558,7 +556,7 @@ async fn run() -> anyhow::Result<()> {
 
             match download_manifest(srvstr, lines).await {
                 Ok(_) => println!("Success!"),
-                Err(e) => println!("Failed: {:#}", e),
+                Err(e) => println!("Failed: {:?}", e),
             }
         }
         Some(("download_single", matches)) => {
@@ -622,7 +620,7 @@ async fn run() -> anyhow::Result<()> {
                 },
                 Err(e) => {
                     match message_format {
-                        MessageFormat::Human => println!("operation failed: {e:#}"),
+                        MessageFormat::Human => println!("operation failed: {e:?}"),
                         MessageFormat::Json => println!(
                             "{}",
                             json!({

--- a/crates/symsrv/src/lib.rs
+++ b/crates/symsrv/src/lib.rs
@@ -53,8 +53,11 @@ impl ToString for PdbInfo {
 #[derive(Error, Debug)]
 pub enum DownloadError {
     /// Server returned a 404 error. Try the next one.
-    #[error("Server returned 404 not found")]
+    #[error("server returned 404 not found")]
     FileNotFound,
+
+    #[error("error requesting file")]
+    Request(#[from] reqwest::Error),
 
     #[error(transparent)]
     Other(#[from] anyhow::Error),

--- a/crates/symsrv/src/nonblocking.rs
+++ b/crates/symsrv/src/nonblocking.rs
@@ -256,7 +256,8 @@ fn connect_server(srv: &SymSrvSpec) -> anyhow::Result<reqwest::Client> {
     // Determine if the URL is a known URL that requires OAuth2 authorization.
     use url::{Host, Url};
 
-    let url = Url::parse(&srv.server_url)?;
+    let url = Url::parse(&srv.server_url).context("invalid URL")?;
+    println!("{url:?}");
     match url.host() {
         Some(Host::Domain(d)) => {
             match d {

--- a/crates/symsrv/src/nonblocking.rs
+++ b/crates/symsrv/src/nonblocking.rs
@@ -73,8 +73,7 @@ async fn download_single(
         let pdb_req = client
             .get::<&str>(&format!("{}/{}", file_folder_url, name))
             .send()
-            .await
-            .context("failed to request remote file")?;
+            .await?;
         if pdb_req.status().is_success() {
             if let Some(mime) = pdb_req.headers().get(reqwest::header::CONTENT_TYPE) {
                 let mime = mime
@@ -98,8 +97,7 @@ async fn download_single(
             let fileptr_req = client
                 .get::<&str>(&format!("{}/file.ptr", file_folder_url))
                 .send()
-                .await
-                .context("failed to request file.ptr")?;
+                .await?;
             if !fileptr_req.status().is_success() {
                 // Attempt another server instead
                 Err(DownloadError::FileNotFound)?;
@@ -256,8 +254,8 @@ fn connect_server(srv: &SymSrvSpec) -> anyhow::Result<reqwest::Client> {
     // Determine if the URL is a known URL that requires OAuth2 authorization.
     use url::{Host, Url};
 
-    let url = Url::parse(&srv.server_url).context("invalid URL")?;
-    println!("{url:?}");
+    let url = Url::parse(&srv.server_url)
+        .context(format!("invalid server URL: \"{}\"", &srv.server_url))?;
     match url.host() {
         Some(Host::Domain(d)) => {
             match d {


### PR DESCRIPTION
Before:
```
     Running `target\debug\pdblister.exe download_single srv*D:\Symbols* C:\Windows\System32\notepad.exe`
operation failed: failed to connect to server SRV*D:\Symbols*: relative URL without a base
```

After:
```
     Running `target\debug\pdblister.exe download_single srv*D:\Symbols* C:\Windows\System32\notepad.exe`
operation failed: failed to connect to server SRV*D:\Symbols*

Caused by:
    0: invalid server URL: ""
    1: relative URL without a base
```

Fixes #36 