### PR TITLE
Feature/kernel crashdump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,9 +112,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bumpalo"
@@ -576,6 +576,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kdmp-parser"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9020e118f80785d03e42307666fbbff8cb5cf11ac06f8a662c528191ac040404"
+dependencies = [
+ "bitflags 2.6.0",
+ "thiserror",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,7 +706,7 @@ version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -777,6 +787,7 @@ dependencies = [
  "clap",
  "futures",
  "indicatif",
+ "kdmp-parser",
  "mime",
  "pdb",
  "rand",
@@ -931,7 +942,7 @@ version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ base64 = "0.13"
 clap = { version = "4.4.11", features = ["derive"] }
 futures = "0.3"
 indicatif = { version = "0.17.2", features = ["tokio"] }
+kdmp-parser = "0.5.0"
 mime = "0.3"
 pdb = "0.8.0"
 rand = "0.8"

--- a/src/kernel_crashdump.rs
+++ b/src/kernel_crashdump.rs
@@ -1,0 +1,122 @@
+use std::{
+    convert::TryInto,
+    ffi::OsStr,
+    io::{ErrorKind, Read, Seek},
+    ops::Range,
+    path::Path,
+};
+
+use anyhow::Context;
+use kdmp_parser::{Gva, Gxa};
+
+use crate::{get_pdb_from_reader, pe};
+
+struct DumpPE<'a> {
+    dump: &'a kdmp_parser::KernelDumpParser,
+    pe_range: &'a Range<Gva>,
+    offset: isize,
+}
+
+impl<'a> Read for &mut DumpPE<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        // Trim the read to the end of the buffer in case it exceeds the PE in memory
+        let pe_len: isize = (self.pe_range.end.u64() - self.pe_range.start.u64())
+            .try_into()
+            .unwrap();
+        let read_size: usize = std::cmp::min(buf.len(), (pe_len - self.offset).try_into().unwrap());
+
+        // Calculate the Gva to perform the read at
+        let read_addr = Gva::new(self.pe_range.start.u64() + self.offset as u64);
+
+        // Do the read
+        match self.dump.virt_read(read_addr, &mut buf[0..read_size]) {
+            Ok(read_bytes) => {
+                let read_bytes_signed: isize = read_bytes.try_into().unwrap();
+                self.offset += read_bytes_signed;
+                Ok(read_bytes)
+            }
+            Err(err) => Err(std::io::Error::new(ErrorKind::Other, err)),
+        }
+    }
+}
+
+impl<'a> Seek for &mut DumpPE<'a> {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+        let new_offset: isize = match pos {
+            std::io::SeekFrom::Current(x) => {
+                let cur: i64 = self.offset.try_into().unwrap();
+                (cur + x).try_into().unwrap()
+            }
+            std::io::SeekFrom::End(x) => {
+                let end: i64 = self.pe_range.end.u64().try_into().unwrap();
+                (end + x).try_into().unwrap()
+            }
+            std::io::SeekFrom::Start(x) => x.try_into().unwrap(),
+        };
+
+        self.offset = new_offset.try_into().unwrap();
+
+        Ok(self.offset.try_into().unwrap())
+    }
+}
+
+pub(crate) fn get_module_list_from_kernel_crash(
+    crash: &Path,
+    binaries: bool,
+    include_user: bool,
+) -> anyhow::Result<Vec<String>> {
+    // Map the crashdump
+    let reader =
+        kdmp_parser::MappedFileReader::new(crash).context("failed to map kernel crashdump")?;
+    let dump = kdmp_parser::KernelDumpParser::with_reader(reader)
+        .context("failed to parse kernel crashdump")?;
+
+    let mut manifest = Vec::new();
+
+    let module_iter = dump.kernel_modules().chain(
+        // If we're including user modules, chain it in
+        if include_user {
+            Some(dump.user_modules())
+        } else {
+            None
+        }
+        .into_iter()
+        .flatten(),
+    );
+
+    for (module_range, module) in module_iter {
+        let mut module_reader = DumpPE {
+            dump: &dump,
+            offset: 0,
+            pe_range: module_range,
+        };
+
+        // If we're getting binaries too, record that now
+        if binaries {
+            // Get the base file name of the module
+            let mut bin_name = module;
+            if let Some(stem) = Path::new(module).file_name().and_then(OsStr::to_str) {
+                bin_name = stem;
+            }
+
+            match pe::parse_pe(&mut module_reader) {
+                Ok((_, _, pe_header, image_size, _)) => {
+                    let timestamp = pe_header.timestamp;
+                    manifest.push(format!("{},{:x}{:x},2", bin_name, timestamp, image_size));
+                }
+                Err(err) => {
+                    eprintln!("Failed to get PE  for module '{}': {}", module, err)
+                }
+            }
+
+            (&mut module_reader).seek(std::io::SeekFrom::Start(0))?;
+        }
+
+        match get_pdb_from_reader(&mut module_reader) {
+            Ok(manifest_entry) => manifest.push(manifest_entry),
+            Err(err) => eprintln!("Failed to get PDB for module '{}': {}", module, err),
+        }
+    }
+
+    Ok(manifest)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,9 @@ fn get_pdb_path<P: AsRef<Path>>(pdbname: P) -> anyhow::Result<PathBuf> {
 }
 
 fn get_file_path(filename: &Path) -> anyhow::Result<String> {
-    let (_, _, pe_header, image_size, _) = pe::parse_pe(filename)?;
+    let fd = std::fs::File::open(filename)?;
+
+    let (_, _, pe_header, image_size, _) = pe::parse_pe(fd)?;
 
     let filename = filename
         .file_name()
@@ -135,7 +137,20 @@ fn get_file_path(filename: &Path) -> anyhow::Result<String> {
 /// Returns a string which is the same representation you get from `symchk`
 /// when outputting a manifest for the PDB "<filename>,<guid><age>,1"
 fn get_pdb(filename: &Path) -> anyhow::Result<String> {
-    let (mut fd, mz_header, pe_header, _, num_tables) = pe::parse_pe(filename)?;
+    let fd = std::fs::File::open(filename)?;
+
+    get_pdb_from_reader(fd)
+}
+
+/// Given a `reader`, attempt to parse out any mention of a PDB file in it.
+///
+/// This returns success if it successfully parses the MZ, PE, finds a debug
+/// header, matches RSDS signature, and contains a valid reference to a PDB.
+///
+/// Returns a string which is the same representation you get from `symchk`
+/// when outputting a manifest for the PDB "<filename>,<guid><age>,1"
+fn get_pdb_from_reader(fd: impl Read + Seek) -> anyhow::Result<String> {
+    let (mut fd, mz_header, pe_header, _, num_tables) = pe::parse_pe(fd)?;
 
     /* Load all the data directories into a vector */
     let mut data_dirs = Vec::new();

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -159,7 +159,7 @@ pub const IMAGE_DEBUG_TYPE_CODEVIEW: u32 = 2;
 
 /// Read a structure from a file stream, directly interpreting the raw bytes
 /// of the file as T.
-pub fn read_struct<T: AsBytes + FromBytes>(fd: &mut (impl Read + Seek)) -> io::Result<T> {
+pub fn read_struct<T: AsBytes + FromBytes>(mut fd: impl Read + Seek) -> io::Result<T> {
     let mut ret: T = T::new_zeroed();
     fd.read_exact(ret.as_bytes_mut())?;
 


### PR DESCRIPTION
On top of #63, this adds support for kernel crashdumps in addition to the usermode crashdumps. Active, Kernel, Complete, and Automatic crashdump types are supported (as denoted by the "Startup and Recovery  -> Write debugging information" dialog). Live dumps (Task Manager -> System -> Create live kernel memory dump file) are also supported. Small dump types are not supported due to the underlying parser (kdmp-parser) not supporting them.

@microsoft-github-policy-service agree