### PR TITLE
Add `#[clap(long)]` attribute to `message_format` argument

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -428,6 +428,7 @@ enum Command {
         /// The PE file path
         filepath: PathBuf,
         /// The format to print the message in
+        #[clap(long)]
         message_format: MessageFormat,
     },
     /// Recursively searches a directory tree and caches all PEs in the current directory in a symbol cache layout


### PR DESCRIPTION
This was mistakenly omitted when I originally set up these arguments, but we always want users to specify `--message-format` (rather than having it be a positional argument)